### PR TITLE
feat: keep eslint packages in sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,7 @@ updates:
         patterns:
           - "vitest"
           - "@vitest/coverage-v8"
+      eslint-core:
+        patterns:
+          - "eslint"
+          - "@eslint/js"


### PR DESCRIPTION
This PR configures Dependabot to keep core eslint pages in sync:

- eslint
- @eslint/js